### PR TITLE
Applying new line height text utilities

### DIFF
--- a/utilities/_u-text.scss
+++ b/utilities/_u-text.scss
@@ -67,15 +67,45 @@ $u-text-breakpoint-toggle-weight-inherit:         false !default;
 
 $u-text-breakpoint-toggle-weight-normal:          false !default;
 
-$u-text-breakpoint-toggle-transform-uppercase:   false !default;
+$u-text-breakpoint-toggle-transform-uppercase:    false !default;
 
-$u-text-breakpoint-toggle-transform-lowercase:   false !default;
+$u-text-breakpoint-toggle-transform-lowercase:    false !default;
 
-$u-text-breakpoint-toggle-transform-capitalise:  false !default;
+$u-text-breakpoint-toggle-transform-capitalise:   false !default;
 
-$u-text-breakpoint-toggle-transform-inherit:     false !default;
+$u-text-breakpoint-toggle-transform-inherit:      false !default;
 
-$u-text-breakpoint-toggle-transform-none:        false !default;
+$u-text-breakpoint-toggle-transform-none:         false !default;
+
+$u-text-breakpoint-toggle-line-height-0-5:        false !default;
+
+$u-text-breakpoint-toggle-line-height-1:          false !default;
+
+$u-text-breakpoint-toggle-line-height-1-1:        false !default;
+
+$u-text-breakpoint-toggle-line-height-1-2:        false !default;
+
+$u-text-breakpoint-toggle-line-height-1-3:        false !default;
+
+$u-text-breakpoint-toggle-line-height-1-4:        false !default;
+
+$u-text-breakpoint-toggle-line-height-1-5:        false !default;
+
+$u-text-breakpoint-toggle-line-height-1-6:        false !default;
+
+$u-text-breakpoint-toggle-line-height-1-7:        false !default;
+
+$u-text-breakpoint-toggle-line-height-1-8:        false !default;
+
+$u-text-breakpoint-toggle-line-height-1-9:        false !default;
+
+$u-text-breakpoint-toggle-line-height-2:          false !default;
+
+$u-text-breakpoint-toggle-line-height-2-5:        false !default;
+
+$u-text-breakpoint-toggle-line-height-normal:     false !default;
+
+$u-text-breakpoint-toggle-line-height-inherit:    false !default;
 
 $u-text-breakpoint-toggle-colour-white:           false !default;
 
@@ -358,56 +388,128 @@ $u-text-breakpoint-toggle-hyphenate:              false !default;
  *
  * N.B. setting custom line heights should be avoided in favour of trying to
  * keep a consistent vertical rhythm. The `@font-size` mixin takes care of this
- * by applying appriopiate line heights based on the size of the font.
+ * by applying appropiate line heights based on the size of the font.
  */
 
 %u-text-line-height-0-5,
 .u-text-line-height-0-5 {line-height: 0.5;}
 
+@if $u-text-breakpoint-toggle-line-height-0-5 {
+  @include generate-at-breakpoints('.u-text-line-height-0-5',
+    $u-text-breakpoints) {line-height: 0.5;}
+}// end if
+
 %u-text-line-height-1,
 .u-text-line-height-1 {line-height: 1;}
+
+@if $u-text-breakpoint-toggle-line-height-1 {
+  @include generate-at-breakpoints('.u-text-line-height-1',
+    $u-text-breakpoints) {line-height: 1;}
+}// end if
 
 %u-text-line-height-1-1,
 .u-text-line-height-1-1 {line-height: 1.1;}
 
+@if $u-text-breakpoint-toggle-line-height-1-1 {
+  @include generate-at-breakpoints('.u-text-line-height-1-1',
+    $u-text-breakpoints) {line-height: 1.1;}
+}// end if
+
 %u-text-line-height-1-2,
 .u-text-line-height-1-2 {line-height: 1.2;}
+
+@if $u-text-breakpoint-toggle-line-height-1-2 {
+  @include generate-at-breakpoints('.u-text-line-height-1-2',
+    $u-text-breakpoints) {line-height: 1.2;}
+}// end if
 
 %u-text-line-height-1-3,
 .u-text-line-height-1-3 {line-height: 1.3;}
 
+@if $u-text-breakpoint-toggle-line-height-1-3 {
+  @include generate-at-breakpoints('.u-text-line-height-1-3',
+    $u-text-breakpoints) {line-height: 1.3;}
+}// end if
+
 %u-text-line-height-1-4,
 .u-text-line-height-1-4 {line-height: 1.4;}
+
+@if $u-text-breakpoint-toggle-line-height-1-4 {
+  @include generate-at-breakpoints('.u-text-line-height-1-4',
+    $u-text-breakpoints) {line-height: 1.4;}
+}// end if
 
 %u-text-line-height-1-5,
 .u-text-line-height-1-5 {line-height: 1.5;}
 
+@if $u-text-breakpoint-toggle-line-height-1-5 {
+  @include generate-at-breakpoints('.u-text-line-height-1-5',
+    $u-text-breakpoints) {line-height: 1.5;}
+}// end if
+
 %u-text-line-height-1-6,
 .u-text-line-height-1-6 {line-height: 1.6;}
+
+@if $u-text-breakpoint-toggle-line-height-1-6 {
+  @include generate-at-breakpoints('.u-text-line-height-1-6',
+    $u-text-breakpoints) {line-height: 1.6;}
+}// end if
 
 %u-text-line-height-1-7,
 .u-text-line-height-1-7 {line-height: 1.7;}
 
+@if $u-text-breakpoint-toggle-line-height-1-7 {
+  @include generate-at-breakpoints('.u-text-line-height-1-7',
+    $u-text-breakpoints) {line-height: 1.7;}
+}// end if
+
 %u-text-line-height-1-8,
 .u-text-line-height-1-8 {line-height: 1.8;}
+
+@if $u-text-breakpoint-toggle-line-height-1-8 {
+  @include generate-at-breakpoints('.u-text-line-height-1-8',
+    $u-text-breakpoints) {line-height: 1.8;}
+}// end if
 
 %u-text-line-height-1-9,
 .u-text-line-height-1-9 {line-height: 1.9;}
 
+@if $u-text-breakpoint-toggle-line-height-1-9 {
+  @include generate-at-breakpoints('.u-text-line-height-1-9',
+    $u-text-breakpoints) {line-height: 1.9;}
+}// end if
+
 %u-text-line-height-2,
 .u-text-line-height-2 {line-height: 2;}
+
+@if $u-text-breakpoint-toggle-line-height-2 {
+  @include generate-at-breakpoints('.u-text-line-height-2',
+    $u-text-breakpoints) {line-height: 2;}
+}// end if
 
 %u-text-line-height-2-5,
 .u-text-line-height-2-5 {line-height: 2.5;}
 
+@if $u-text-breakpoint-toggle-line-height-2-5 {
+  @include generate-at-breakpoints('.u-text-line-height-2-5',
+    $u-text-breakpoints) {line-height: 2.5;}
+}// end if
+
 %u-text-line-height-normal,
 .u-text-line-height-normal {line-height: normal;}
+
+@if $u-text-breakpoint-toggle-line-height-normal {
+  @include generate-at-breakpoints('.u-text-line-height-normal',
+    $u-text-breakpoints) {line-height: normal;}
+}// end if
 
 %u-text-line-height-inherit,
 .u-text-line-height-inherit {line-height: inherit;}
 
-%u-text-line-height-none,
-.u-text-line-height-none {line-height: none;}
+@if $u-text-breakpoint-toggle-line-height-inherit {
+  @include generate-at-breakpoints('.u-text-line-height-inherit',
+    $u-text-breakpoints) {line-height: inherit;}
+}// end if
 
 
 /**

--- a/utilities/_u-text.scss
+++ b/utilities/_u-text.scss
@@ -354,6 +354,63 @@ $u-text-breakpoint-toggle-hyphenate:              false !default;
 
 
 /**
+ * Line height.
+ *
+ * N.B. setting custom line heights should be avoided in favour of trying to
+ * keep a consistent vertical rhythm. The `@font-size` mixin takes care of this
+ * by applying appriopiate line heights based on the size of the font.
+ */
+
+%u-text-line-height-0-5,
+.u-text-line-height-0-5 {line-height: 0.5;}
+
+%u-text-line-height-1,
+.u-text-line-height-1 {line-height: 1;}
+
+%u-text-line-height-1-1,
+.u-text-line-height-1-1 {line-height: 1.1;}
+
+%u-text-line-height-1-2,
+.u-text-line-height-1-2 {line-height: 1.2;}
+
+%u-text-line-height-1-3,
+.u-text-line-height-1-3 {line-height: 1.3;}
+
+%u-text-line-height-1-4,
+.u-text-line-height-1-4 {line-height: 1.4;}
+
+%u-text-line-height-1-5,
+.u-text-line-height-1-5 {line-height: 1.5;}
+
+%u-text-line-height-1-6,
+.u-text-line-height-1-6 {line-height: 1.6;}
+
+%u-text-line-height-1-7,
+.u-text-line-height-1-7 {line-height: 1.7;}
+
+%u-text-line-height-1-8,
+.u-text-line-height-1-8 {line-height: 1.8;}
+
+%u-text-line-height-1-9,
+.u-text-line-height-1-9 {line-height: 1.9;}
+
+%u-text-line-height-2,
+.u-text-line-height-2 {line-height: 2;}
+
+%u-text-line-height-2-5,
+.u-text-line-height-2-5 {line-height: 2.5;}
+
+%u-text-line-height-normal,
+.u-text-line-height-normal {line-height: normal;}
+
+%u-text-line-height-inherit,
+.u-text-line-height-inherit {line-height: inherit;}
+
+%u-text-line-height-none,
+.u-text-line-height-none {line-height: none;}
+
+
+/**
  * Colour.
  */
 


### PR DESCRIPTION
This closes issue #8.

@kllevin do you think there needs to be `@generate-at-breakpoint` versions?