### PR TITLE
Add ability to also generate percentage-based width class names

### DIFF
--- a/core/mixins/_generate-percentage-classes-at-breakpoints.scss
+++ b/core/mixins/_generate-percentage-classes-at-breakpoints.scss
@@ -34,7 +34,7 @@ $mixin-numerators:            (one two three four five six seven eight nine
 $mixin-denominator-words:     (whole half third quarter fifth sixth seventh
                               eighth ninth tenth eleventh twelfth) !default;
 
-$apply-percentage-classnames: false !default;
+$mixin-percentage-classnames: false !default;
 
 @mixin generate-percentage-classes-at-breakpoints($breakpoint-names,
   $scally-type: "u", $class-name: null, $css-property: "width") {
@@ -74,7 +74,7 @@ $apply-percentage-classnames: false !default;
     @for $numerator from 1 through max($denominator - 1, 1) {
       $denominator-suffix: if($numerator == 1, "", "s");
       
-      @if $apply-percentage-classnames {
+      @if $mixin-percentage-classnames {
         $percent-width-class: ($numerator/$denominator) * 100;
         @if round($percent-width-class) == ceil($percent-width-class) {
           $percent-width-class: ceil($percent-width-class);

--- a/core/mixins/_generate-percentage-classes-at-breakpoints.scss
+++ b/core/mixins/_generate-percentage-classes-at-breakpoints.scss
@@ -34,6 +34,7 @@ $mixin-numerators:            (one two three four five six seven eight nine
 $mixin-denominator-words:     (whole half third quarter fifth sixth seventh
                               eighth ninth tenth eleventh twelfth) !default;
 
+$apply-percentage-classnames: false !default;
 
 @mixin generate-percentage-classes-at-breakpoints($breakpoint-names,
   $scally-type: "u", $class-name: null, $css-property: "width") {
@@ -72,10 +73,30 @@ $mixin-denominator-words:     (whole half third quarter fifth sixth seventh
   @each $denominator in $mixin-denominator-numbers {
     @for $numerator from 1 through max($denominator - 1, 1) {
       $denominator-suffix: if($numerator == 1, "", "s");
-
-      .#{$scally-type}-#{$class-name}#{nth($mixin-numerators,
-        $numerator)}-#{nth($mixin-denominator-words,
-          $denominator)#{$denominator-suffix}#{$breakpoint}} {#{$css-property}: percentage($numerator/$denominator);}
+      
+      @if $apply-percentage-classnames {
+        $percent-width-class: ($numerator/$denominator) * 100;
+        @if round($percent-width-class) == ceil($percent-width-class) {
+          $percent-width-class: ceil($percent-width-class);
+        }
+        @else {
+          $percent-width-class: floor($percent-width-class);
+        }
+        
+        .#{$scally-type}-#{$class-name}#{nth($mixin-numerators,
+          $numerator)}-#{nth($mixin-denominator-words,
+            $denominator)#{$denominator-suffix}#{$breakpoint}},
+        .#{$scally-type}-#{$class-name}#{$percent-width-class}pc#{$breakpoint} {
+          #{$css-property}: percentage($numerator/$denominator);
+        }
+      }
+      @else {
+        .#{$scally-type}-#{$class-name}#{nth($mixin-numerators,
+          $numerator)}-#{nth($mixin-denominator-words,
+            $denominator)#{$denominator-suffix}#{$breakpoint}} {
+              #{$css-property}: percentage($numerator/$denominator);
+        }
+      }
     }
   }
-}
+}  


### PR DESCRIPTION
Provides an option (`$apply-percentage-classnames`) which is false by default, that, when enabled, also creates u-[integer]pc(-from-[bp]) classes alongside the standard width classes, e.g: `.u-25pc {}`, `u-67-from-lap {}` etc.

If the fractional part of the width is greater than 0.5, the percent will be rounded up to the nearest integer, otherwise it's rounded down.
