### PR TITLE
Fix headings and GPCaB mixins to work with LibSass

### DIFF
--- a/core/mixins/_generate-percentage-classes-at-breakpoints.scss
+++ b/core/mixins/_generate-percentage-classes-at-breakpoints.scss
@@ -138,7 +138,7 @@ $mixin-apply-terse-percentage-class-names: false !default;
 
         .#{$scally-type}-#{$class-name}#{nth($mixin-numerators,
           $numerator)}-#{nth($mixin-denominator-words,
-            $denominator)#{$denominator-suffix}#{$breakpoint}},
+            $denominator)}#{$denominator-suffix}#{$breakpoint},
         .#{$scally-type}-#{$class-name}#{$percent-width-class}pc#{$breakpoint} {
           #{$css-property}: percentage($numerator/$denominator);
         }
@@ -146,7 +146,7 @@ $mixin-apply-terse-percentage-class-names: false !default;
       @else {
         .#{$scally-type}-#{$class-name}#{nth($mixin-numerators,
           $numerator)}-#{nth($mixin-denominator-words,
-            $denominator)#{$denominator-suffix}#{$breakpoint}} {
+            $denominator)}#{$denominator-suffix}#{$breakpoint} {
               #{$css-property}: percentage($numerator/$denominator);
         }
       }

--- a/core/mixins/_target-headings.scss
+++ b/core/mixins/_target-headings.scss
@@ -29,13 +29,10 @@
         $selector: "#{$selector}, .#{$selector}";
       }
 
-      $selector-list: append($selector-list, $selector);
+      $selector-list: append($selector-list, unquote($selector), comma);
     }
 
-    // Combine and output all selectors with css content
-    $full-selector: join($selector-list, (), "comma");
-
-    #{$full-selector} {
+    #{$selector-list} {
       @content
     }
   }


### PR DESCRIPTION
The `headings()` and `generate-percentage-classes()` mixins errored when compiled with LibSass. This PR fixes that, while maintaining Ruby Sass support.

To test:
- Add the following to your package.json

```
,
  "devDependencies": {
    "grunt": "~0.4.5",
    "grunt-cli": "~0.1.13",
    "grunt-sass": "^0.18.1"
  }
```
- Save the following as Gruntfile.js

```

module.exports = function(grunt) {
  grunt.initConfig({

    sass: {
      dev: {
        files: [{
          src: 'style.scss',
          dest: 'style-libsass.css',
        }]
      }
    }
  });

  grunt.loadNpmTasks('grunt-sass');

  grunt.registerTask('default', ['sass:dev']);
};

```
- run `npm install`
- run `grunt`
- Compare style.css to style-libsass.css

I'd run them both through a minifier first, and you'll see the only changes are that LibSass puts 10 decimals places on width percentages, compared to 5 with Ruby Sass.
