### PR TITLE
Converted to-em/rem mixins to be generic & fixed bugs

### DIFF
--- a/core/base/_headings.scss
+++ b/core/base/_headings.scss
@@ -28,7 +28,7 @@ $apply-heading-margins: true !default;
  * Set margins but make optional.
  */
 
-@if $apply-heading-margins {
+/*@if $apply-heading-margins {
   // Base
   @include headings(1, 3, true) {
     @extend %c-bottom-spacing;
@@ -38,7 +38,7 @@ $apply-heading-margins: true !default;
   @include headings(4, 6, true) {
     @extend %c-bottom-spacing-half;
   }
-}// endif
+}// endif*/
 
 
 /**

--- a/core/mixins/_convert-px-to-em-rem.scss
+++ b/core/mixins/_convert-px-to-em-rem.scss
@@ -53,7 +53,7 @@
     }
 
     @else {
-      $values: append($values, if(type-of($s) == number, #{$s / $context}#{$unit},
+      $values: append($values, if(type-of($s) == number and $s != 0, #{$s / $context}#{$unit},
         $s));
     }
   }

--- a/core/mixins/_convert-px-to-em-rem.scss
+++ b/core/mixins/_convert-px-to-em-rem.scss
@@ -27,14 +27,17 @@
 
 
 /**
- * `em`.
+ * `em-or-rem`.
+ *
+ * Generic mixin which is used by the `to-em` and `to-rem` mixins below
  */
 
-@mixin to-em($properties, $sizes, $context: $font-size, $sledgehammer: false) {
+@mixin to-em-or-rem($unit, $properties, $sizes, $context, $sledgehammer) {
 
   $values: ();
   $sublists: false;
-  $important: if($sledgehammer, "!important", "");
+  $unit: if($unit == "em", unquote("em"), unquote("rem"));
+  $important: if($sledgehammer, " !important", "");
 
   @each $s in $sizes {
 
@@ -43,14 +46,14 @@
       $vv: ();
 
       @each $ss in $s {
-        $vv: append($vv, if(type-of($ss) == number, #{$ss / $context}em, $ss));
+        $vv: append($vv, if(type-of($ss) == number and $ss != 0, #{$ss / $context}#{$unit}, $ss));
       }
 
       $values: append($values, join((), $vv));
     }
 
     @else {
-      $values: append($values, if(type-of($s) == number, #{$s / $context}em,
+      $values: append($values, if(type-of($s) == number, #{$s / $context}#{$unit},
         $s));
     }
   }
@@ -64,37 +67,19 @@
 
 
 /**
+ * `em`.
+ */
+
+@mixin to-em($properties, $sizes, $context: false, $sledgehammer: false) {
+  $context: if($context, $context, $font-size);
+  @include to-em-or-rem("em", $properties, $sizes, $context, $sledgehammer);
+}
+
+
+/**
  * `rem`.
  */
 
-@mixin to-rem($properties, $sizes, $sledgehammer: "") {
-
-  $values: ();
-  $sublists: false;
-
-  @each $s in $sizes {
-
-    @if type-of($s) == list {
-      $sublists: true;
-      $vv: ();
-
-      @each $ss in $s {
-        $vv: append($vv, if(type-of($ss) == number, #{$ss / $font-size}rem,
-          $ss));
-      }
-
-      $values: append($values, join((), $vv));
-    }
-
-    @else {
-      $values: append($values, if(type-of($s) == number, #{$s / $font-size}rem,
-        $s));
-    }
-  }
-
-  $value: join((), $values, if($sublists, comma, space));
-
-  @each $prop in $properties {
-    #{$prop}: $value#{$sledgehammer};
-  }
+@mixin to-rem($properties, $sizes, $sledgehammer: false) {
+  @include to-em-or-rem("rem", $properties, $sizes, $font-size, $sledgehammer);
 }

--- a/style.css
+++ b/style.css
@@ -42,12 +42,12 @@
  * simply redeclare it above the relevant `@import`, like so:
  *
    $font-size: 14;
-   @import "bower_components/scally/core/settings/typography";
+   @import "core/settings/typography";
  *
  * If you want to use a Scally setting to override something then you need to
  * define the override below the `@import`, like so:
  *
-   @import "bower_components/scally/core/settings/colours";
+   @import "core/settings/colours";
    $colour-text-base: $colour-brand;
  *
  * If you try to redeclare above the `@import` your Sass won't compile as you
@@ -57,7 +57,7 @@
  *
    $u-arrow-size-base: 14;
    $u-arrow-colour: orange;
-   @import "bower_components/scally/utilities/u-arrow";
+   @import "utilities/u-arrow";
  *
  * Scally ignores its own settings in favour of using your own, so you can
  * completely modify how Scally works without ever having to alter the
@@ -343,6 +343,11 @@
  * https://gist.github.com/2237465
  */
 /**
+ * `em-or-rem`.
+ *
+ * Generic mixin which is used by the `to-em` and `to-rem` mixins below
+ */
+/**
  * `em`.
  */
 /**
@@ -545,8 +550,8 @@
  *
  * The percentage classes can be applied at any breakpoint or any of the set
  * breakpoints defined here: Core -> Settings -> Breakpoints. If the breakpoint
- * is set via a min-width media query (the default)—say the 'desk'
- * breakpoint—then the format will be: `.u-one-half-from-desk`, but if the
+ * is set via a min-width media query (the default)ÔÇösay the 'desk'
+ * breakpointÔÇöthen the format will be: `.u-one-half-from-desk`, but if the
  * breakpoint is set via a max-width media query then the format will be:
  * `.u-one-half-up-to-desk`.
  *
@@ -1146,7 +1151,11 @@ ins {
    ========================================================================= */
 /**
  * The root element: `html`.
- *
+ */
+/**
+ * Settings.
+ */
+/**
  * 1. Set the default `font-size`, `line-height` and `font-family` for the
  *    entire project, sourced from the Scally settings. The `font-size` is
  *    calculated to exist in `em`s, the `line-height` is calculated to exist
@@ -1154,13 +1163,10 @@ ins {
  * 2. Fonts on OSX will look more consistent with other systems that do not
  *    render text using sub-pixel anti-aliasing.
  */
-/**
- * Settings.
- */
 html {
   font: 1em/1.5 Arial, sans-serif;
-  color: #000;
-  background: #fff;
+  color: black;
+  background: white;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased; }
 
@@ -1282,8 +1288,8 @@ textarea[disabled],
 textarea,
 select {
   padding: 0.375rem;
-  color: #000;
-  background: #fff;
+  color: black;
+  background: white;
   border: 0.0625rem solid #4d4d4d; }
 
 /**
@@ -1320,12 +1326,23 @@ summary {
 /**
  * Apply font family.
  */
-h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6 {
+"h1, .h1", "h2, .h2", "h3, .h3", "h4, .h4", "h5, .h5", "h6, .h6" {
   font-family: Arial, sans-serif; }
 
 /**
  * Set margins but make optional.
  */
+/*@if $apply-heading-margins {
+  // Base
+  @include headings(1, 3, true) {
+    @extend %c-bottom-spacing;
+  }
+
+  // Half
+  @include headings(4, 6, true) {
+    @extend %c-bottom-spacing-half;
+  }
+}// endif*/
 /**
  * H1.
  */
@@ -1384,7 +1401,7 @@ h6,
 hr {
   display: block;
   border: 0;
-  border: 0.0625rem solid #000;
+  border: 0.0625rem solid black;
   padding: 0; }
 
 /* ============================================================================
@@ -1479,7 +1496,7 @@ canvas {
    */
   * {
     background: transparent !important;
-    color: #000 !important;
+    color: black !important;
     box-shadow: none !important;
     text-shadow: none !important; }
 
@@ -1570,22 +1587,13 @@ canvas {
 /**
  * Base.
  */
-h1, .h1, h2, .h2, h3, .h3, hr, p {
+hr, p {
   margin-bottom: 1.5rem; }
 
 /**
  * Half.
  */
-h4, .h4, h5, .h5, h6, .h6 {
-  margin-bottom: 0.75rem; }
-
-h1:last-child, .h1:last-child, h2:last-child, .h2:last-child, h3:last-child, .h3:last-child, hr:last-child, p:last-child,
-h4:last-child,
-.h4:last-child,
-h5:last-child,
-.h5:last-child,
-h6:last-child,
-.h6:last-child {
+hr:last-child, p:last-child {
   margin-bottom: 0; }
 
 /**
@@ -2212,7 +2220,7 @@ h6:last-child,
  * Modifier: column divider.
  */
 .l-columns--divider {
-  column-rule: 0.0625rem solid #000; }
+  column-rule: 0.0625rem solid black; }
 
 /**
  * COMPONENTS.
@@ -2274,7 +2282,7 @@ h6:last-child,
   .btn--main:hover,
   .btn--main:focus,
   .btn--main:active {
-    color: #fff; }
+    color: white; }
   .btn--main:hover,
   .btn--main:focus {
     opacity: 0.7;
@@ -2289,7 +2297,7 @@ h6:last-child,
   .btn--main--secondary:hover,
   .btn--main--secondary:focus,
   .btn--main--secondary:active {
-    color: #fff; }
+    color: white; }
 
 /**
  * Modifier: tiny padding.
@@ -2435,25 +2443,25 @@ h6:last-child,
  * Modifier: down arrow.
  */
 .u-arrow--down {
-  border-top-color: #000; }
+  border-top-color: black; }
 
 /**
  * Modifier: up arrow.
  */
 .u-arrow--up {
-  border-bottom-color: #000; }
+  border-bottom-color: black; }
 
 /**
  * Modifier: left arrow.
  */
 .u-arrow--left {
-  border-right-color: #000; }
+  border-right-color: black; }
 
 /**
  * Modifier: right arrow.
  */
 .u-arrow--right {
-  border-left-color: #000; }
+  border-left-color: black; }
 
 /* ============================================================================
    @UTILITIES -> LIST
@@ -2708,7 +2716,7 @@ ol.u-list ol {
  * Add a keyline separator between the list items.
  */
 .u-list-inline--divider > li + li {
-  border-left: 0.0625rem solid #000; }
+  border-left: 0.0625rem solid black; }
 
 /**
  * Modifier: fit.
@@ -2929,16 +2937,16 @@ li:before {
  * Colour.
  */
 .u-text-colour-white {
-  color: #fff; }
+  color: white; }
 
 .u-text-colour-black {
-  color: #000; }
+  color: black; }
 
 .u-text-colour-brand {
   color: #2aa198; }
 
 .u-text-colour-text-base {
-  color: #000; }
+  color: black; }
 
 .u-text-colour-text-primary {
   color: #2aa198; }
@@ -3926,7 +3934,7 @@ li:before {
    @UTILITIES -> FLEX EMBED
    ========================================================================= */
 /**
- * For use with media embeds – such as videos, slideshows, or even images –
+ * For use with media embeds ÔÇô such as videos, slideshows, or even images ÔÇô
  * that need to retain a specific aspect ratio but adapt to the width of their
  * containing element.
  *
@@ -4873,6 +4881,466 @@ li:before {
 /**
  * Generates all breakpoint classes.
  */
+@media (min-width: 40.0625em) {
+  .u-s-m-base-from-lap {
+    margin: 1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-m-tiny-from-lap {
+    margin: 0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-m-small-from-lap {
+    margin: 0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-m-large-from-lap {
+    margin: 2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-m-huge-from-lap {
+    margin: 3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-m-n-base-from-lap {
+    margin: -1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-m-n-tiny-from-lap {
+    margin: -0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-m-n-small-from-lap {
+    margin: -0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-m-n-large-from-lap {
+    margin: -2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-m-n-huge-from-lap {
+    margin: -3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-p-base-from-lap {
+    padding: 1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-p-tiny-from-lap {
+    padding: 0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-p-small-from-lap {
+    padding: 0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-p-large-from-lap {
+    padding: 2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-p-huge-from-lap {
+    padding: 3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-p-n-base-from-lap {
+    padding: -1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-p-n-tiny-from-lap {
+    padding: -0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-p-n-small-from-lap {
+    padding: -0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-p-n-large-from-lap {
+    padding: -2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-p-n-huge-from-lap {
+    padding: -3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mt-base-from-lap {
+    margin-top: 1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mt-tiny-from-lap {
+    margin-top: 0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mt-small-from-lap {
+    margin-top: 0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mt-large-from-lap {
+    margin-top: 2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mt-huge-from-lap {
+    margin-top: 3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mt-n-base-from-lap {
+    margin-top: -1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mt-n-tiny-from-lap {
+    margin-top: -0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mt-n-small-from-lap {
+    margin-top: -0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mt-n-large-from-lap {
+    margin-top: -2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mt-n-huge-from-lap {
+    margin-top: -3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pt-base-from-lap {
+    padding-top: 1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pt-tiny-from-lap {
+    padding-top: 0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pt-small-from-lap {
+    padding-top: 0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pt-large-from-lap {
+    padding-top: 2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pt-huge-from-lap {
+    padding-top: 3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pt-n-base-from-lap {
+    padding-top: -1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pt-n-tiny-from-lap {
+    padding-top: -0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pt-n-small-from-lap {
+    padding-top: -0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pt-n-large-from-lap {
+    padding-top: -2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pt-n-huge-from-lap {
+    padding-top: -3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mr-base-from-lap {
+    margin-right: 1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mr-tiny-from-lap {
+    margin-right: 0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mr-small-from-lap {
+    margin-right: 0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mr-large-from-lap {
+    margin-right: 2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mr-huge-from-lap {
+    margin-right: 3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mr-n-base-from-lap {
+    margin-right: -1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mr-n-tiny-from-lap {
+    margin-right: -0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mr-n-small-from-lap {
+    margin-right: -0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mr-n-large-from-lap {
+    margin-right: -2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mr-n-huge-from-lap {
+    margin-right: -3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pr-base-from-lap {
+    padding-right: 1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pr-tiny-from-lap {
+    padding-right: 0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pr-small-from-lap {
+    padding-right: 0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pr-large-from-lap {
+    padding-right: 2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pr-huge-from-lap {
+    padding-right: 3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pr-n-base-from-lap {
+    padding-right: -1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pr-n-tiny-from-lap {
+    padding-right: -0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pr-n-small-from-lap {
+    padding-right: -0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pr-n-large-from-lap {
+    padding-right: -2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pr-n-huge-from-lap {
+    padding-right: -3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mb-base-from-lap {
+    margin-bottom: 1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mb-tiny-from-lap {
+    margin-bottom: 0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mb-small-from-lap {
+    margin-bottom: 0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mb-large-from-lap {
+    margin-bottom: 2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mb-huge-from-lap {
+    margin-bottom: 3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mb-n-base-from-lap {
+    margin-bottom: -1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mb-n-tiny-from-lap {
+    margin-bottom: -0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mb-n-small-from-lap {
+    margin-bottom: -0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mb-n-large-from-lap {
+    margin-bottom: -2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-mb-n-huge-from-lap {
+    margin-bottom: -3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pb-base-from-lap {
+    padding-bottom: 1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pb-tiny-from-lap {
+    padding-bottom: 0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pb-small-from-lap {
+    padding-bottom: 0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pb-large-from-lap {
+    padding-bottom: 2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pb-huge-from-lap {
+    padding-bottom: 3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pb-n-base-from-lap {
+    padding-bottom: -1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pb-n-tiny-from-lap {
+    padding-bottom: -0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pb-n-small-from-lap {
+    padding-bottom: -0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pb-n-large-from-lap {
+    padding-bottom: -2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pb-n-huge-from-lap {
+    padding-bottom: -3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ml-base-from-lap {
+    margin-left: 1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ml-tiny-from-lap {
+    margin-left: 0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ml-small-from-lap {
+    margin-left: 0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ml-large-from-lap {
+    margin-left: 2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ml-huge-from-lap {
+    margin-left: 3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ml-n-base-from-lap {
+    margin-left: -1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ml-n-tiny-from-lap {
+    margin-left: -0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ml-n-small-from-lap {
+    margin-left: -0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ml-n-large-from-lap {
+    margin-left: -2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ml-n-huge-from-lap {
+    margin-left: -3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pl-base-from-lap {
+    padding-left: 1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pl-tiny-from-lap {
+    padding-left: 0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pl-small-from-lap {
+    padding-left: 0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pl-large-from-lap {
+    padding-left: 2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pl-huge-from-lap {
+    padding-left: 3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pl-n-base-from-lap {
+    padding-left: -1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pl-n-tiny-from-lap {
+    padding-left: -0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pl-n-small-from-lap {
+    padding-left: -0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pl-n-large-from-lap {
+    padding-left: -2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pl-n-huge-from-lap {
+    padding-left: -3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ms-base-from-lap {
+    margin-left: 1.5rem;
+    margin-right: 1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ms-tiny-from-lap {
+    margin-left: 0.5rem;
+    margin-right: 0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ms-small-from-lap {
+    margin-left: 0.75rem;
+    margin-right: 0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ms-large-from-lap {
+    margin-left: 2.25rem;
+    margin-right: 2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ms-huge-from-lap {
+    margin-left: 3rem;
+    margin-right: 3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ms-n-base-from-lap {
+    margin-left: -1.5rem;
+    margin-right: -1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ms-n-tiny-from-lap {
+    margin-left: -0.5rem;
+    margin-right: -0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ms-n-small-from-lap {
+    margin-left: -0.75rem;
+    margin-right: -0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ms-n-large-from-lap {
+    margin-left: -2.25rem;
+    margin-right: -2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ms-n-huge-from-lap {
+    margin-left: -3rem;
+    margin-right: -3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ps-base-from-lap {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ps-tiny-from-lap {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ps-small-from-lap {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ps-large-from-lap {
+    padding-left: 2.25rem;
+    padding-right: 2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ps-huge-from-lap {
+    padding-left: 3rem;
+    padding-right: 3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ps-n-base-from-lap {
+    padding-left: -1.5rem;
+    padding-right: -1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ps-n-tiny-from-lap {
+    padding-left: -0.5rem;
+    padding-right: -0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ps-n-small-from-lap {
+    padding-left: -0.75rem;
+    padding-right: -0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ps-n-large-from-lap {
+    padding-left: -2.25rem;
+    padding-right: -2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-ps-n-huge-from-lap {
+    padding-left: -3rem;
+    padding-right: -3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-me-base-from-lap {
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-me-tiny-from-lap {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-me-small-from-lap {
+    margin-top: 0.75rem;
+    margin-bottom: 0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-me-large-from-lap {
+    margin-top: 2.25rem;
+    margin-bottom: 2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-me-huge-from-lap {
+    margin-top: 3rem;
+    margin-bottom: 3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-me-n-base-from-lap {
+    margin-top: -1.5rem;
+    margin-bottom: -1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-me-n-tiny-from-lap {
+    margin-top: -0.5rem;
+    margin-bottom: -0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-me-n-small-from-lap {
+    margin-top: -0.75rem;
+    margin-bottom: -0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-me-n-large-from-lap {
+    margin-top: -2.25rem;
+    margin-bottom: -2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-me-n-huge-from-lap {
+    margin-top: -3rem;
+    margin-bottom: -3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pe-base-from-lap {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pe-tiny-from-lap {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pe-small-from-lap {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pe-large-from-lap {
+    padding-top: 2.25rem;
+    padding-bottom: 2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pe-huge-from-lap {
+    padding-top: 3rem;
+    padding-bottom: 3rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pe-n-base-from-lap {
+    padding-top: -1.5rem;
+    padding-bottom: -1.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pe-n-tiny-from-lap {
+    padding-top: -0.5rem;
+    padding-bottom: -0.5rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pe-n-small-from-lap {
+    padding-top: -0.75rem;
+    padding-bottom: -0.75rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pe-n-large-from-lap {
+    padding-top: -2.25rem;
+    padding-bottom: -2.25rem; } }
+@media (min-width: 40.0625em) {
+  .u-s-pe-n-huge-from-lap {
+    padding-top: -3rem;
+    padding-bottom: -3rem; } }
 /* ============================================================================
    @UTILITIES -> DIVIDER
    ========================================================================= */
@@ -4892,25 +5360,25 @@ li:before {
  * Top.
  */
 .u-divider-top {
-  border-top: 0.0625rem solid #000; }
+  border-top: 0.0625rem solid black; }
 
 /**
  * Right.
  */
 .u-divider-right {
-  border-right: 0.0625rem solid #000; }
+  border-right: 0.0625rem solid black; }
 
 /**
  * Bottom.
  */
 .u-divider-bottom {
-  border-bottom: 0.0625rem solid #000; }
+  border-bottom: 0.0625rem solid black; }
 
 /**
  * Left.
  */
 .u-divider-left {
-  border-left: 0.0625rem solid #000; }
+  border-left: 0.0625rem solid black; }
 
 /* ============================================================================
    @UTILITIES -> OVERFLOW
@@ -5127,5 +5595,3 @@ li:before {
 
 /* Your styles
    ========================================================================= */
-
-/*# sourceMappingURL=style.css.map */

--- a/style.scss
+++ b/style.scss
@@ -52,12 +52,12 @@
  * simply redeclare it above the relevant `@import`, like so:
  *
    $font-size: 14;
-   @import "bower_components/scally/core/settings/typography";
+   @import "core/settings/typography";
  *
  * If you want to use a Scally setting to override something then you need to
  * define the override below the `@import`, like so:
  *
-   @import "bower_components/scally/core/settings/colours";
+   @import "core/settings/colours";
    $colour-text-base: $colour-brand;
  *
  * If you try to redeclare above the `@import` your Sass won't compile as you
@@ -67,7 +67,7 @@
  *
    $u-arrow-size-base: 14;
    $u-arrow-colour: orange;
-   @import "bower_components/scally/utilities/u-arrow";
+   @import "utilities/u-arrow";
  *
  * Scally ignores its own settings in favour of using your own, so you can
  * completely modify how Scally works without ever having to alter the
@@ -93,80 +93,80 @@
  */
 
 // Settings
-@import "bower_components/scally/core/settings/typography";
+@import "core/settings/typography";
 
-@import "bower_components/scally/core/settings/spacing";
+@import "core/settings/spacing";
 
-@import "bower_components/scally/core/settings/breakpoints";
+@import "core/settings/breakpoints";
 
-@import "bower_components/scally/core/settings/widths";
+@import "core/settings/widths";
 
-@import "bower_components/scally/core/settings/colours";
+@import "core/settings/colours";
 
-@import "bower_components/scally/core/settings/positioning";
+@import "core/settings/positioning";
 
-@import "bower_components/scally/core/settings/cosmetics";
+@import "core/settings/cosmetics";
 
 // Functions
-@import "bower_components/scally/core/functions/convert-px-to-em-rem";
+@import "core/functions/convert-px-to-em-rem";
 
-@import "bower_components/scally/core/functions/math-helpers";
+@import "core/functions/math-helpers";
 
-@import "bower_components/scally/core/functions/string-replace";
+@import "core/functions/string-replace";
 
 // Mixins
-@import "bower_components/scally/core/mixins/convert-px-to-em-rem";
+@import "core/mixins/convert-px-to-em-rem";
 
-@import "bower_components/scally/core/mixins/font-size";
+@import "core/mixins/font-size";
 
-@import "bower_components/scally/core/mixins/gradients";
+@import "core/mixins/gradients";
 
-@import "bower_components/scally/core/mixins/media-queries";
+@import "core/mixins/media-queries";
 
-@import "bower_components/scally/core/mixins/generate-at-breakpoints";
+@import "core/mixins/generate-at-breakpoints";
 
-@import "bower_components/scally/core/mixins/generate-percentage-classes-at-breakpoints";
+@import "core/mixins/generate-percentage-classes-at-breakpoints";
 
-@import "bower_components/scally/core/mixins/retina-bg-image";
+@import "core/mixins/retina-bg-image";
 
-@import "bower_components/scally/core/mixins/target-browsers";
+@import "core/mixins/target-browsers";
 
-@import "bower_components/scally/core/mixins/target-headings";
+@import "core/mixins/target-headings";
 
 // Normalize
-@import "bower_components/scally/core/normalize";
+@import "core/normalize";
 
 // Reset
-@import "bower_components/scally/core/reset";
+@import "core/reset";
 
 // Debug
-@import "bower_components/scally/core/debug";
+@import "core/debug";
 
 // Base
-@import "bower_components/scally/core/base/root";
+@import "core/base/root";
 
-@import "bower_components/scally/core/base/abbreviation";
+@import "core/base/abbreviation";
 
-@import "bower_components/scally/core/base/forms";
+@import "core/base/forms";
 
-@import "bower_components/scally/core/base/details";
+@import "core/base/details";
 
-@import "bower_components/scally/core/base/headings";
+@import "core/base/headings";
 
-@import "bower_components/scally/core/base/horizontal-rule";
+@import "core/base/horizontal-rule";
 
-@import "bower_components/scally/core/base/links";
+@import "core/base/links";
 
-@import "bower_components/scally/core/base/media";
+@import "core/base/media";
 
-@import "bower_components/scally/core/base/paragraphs";
+@import "core/base/paragraphs";
 
-@import "bower_components/scally/core/base/print";
+@import "core/base/print";
 
-@import "bower_components/scally/core/base/viewport";
+@import "core/base/viewport";
 
 // Placeholders
-@import "bower_components/scally/core/placeholders/c-bottom-spacing";
+@import "core/placeholders/c-bottom-spacing";
 
 
 /**
@@ -174,88 +174,88 @@
  */
 
 // Main container
-@import "bower_components/scally/layout/l-container";
+@import "layout/l-container";
 
 // Grid
-@import "bower_components/scally/layout/l-grid";
+@import "layout/l-grid";
 
-@import "bower_components/scally/layout/l-grid-pull";
+@import "layout/l-grid-pull";
 
-@import "bower_components/scally/layout/l-grid-push";
+@import "layout/l-grid-push";
 
 // Side-by-side
-@import "bower_components/scally/layout/l-side-by-side";
+@import "layout/l-side-by-side";
 
-@import "bower_components/scally/layout/l-side-by-side-alt";
+@import "layout/l-side-by-side-alt";
 
 // CSS3 columns
-@import "bower_components/scally/layout/l-columns";
+@import "layout/l-columns";
 
 
 /**
  * COMPONENTS.
  */
 
-@import "bower_components/scally/components/button";
+@import "components/button";
 
 
 /**
  * UTILITIES.
  */
 
-@import "bower_components/scally/utilities/u-clear-fix";
+@import "utilities/u-clear-fix";
 
-@import "bower_components/scally/utilities/u-arrow";
+@import "utilities/u-arrow";
 
-@import "bower_components/scally/utilities/u-list";
+@import "utilities/u-list";
 
-@import "bower_components/scally/utilities/u-list-block";
+@import "utilities/u-list-block";
 
-@import "bower_components/scally/utilities/u-list-inline";
+@import "utilities/u-list-inline";
 
-@import "bower_components/scally/utilities/u-text";
+@import "utilities/u-text";
 
-@import "bower_components/scally/utilities/u-widths";
+@import "utilities/u-widths";
 
-@import "bower_components/scally/utilities/u-table";
+@import "utilities/u-table";
 
-@import "bower_components/scally/utilities/u-drop-down";
+@import "utilities/u-drop-down";
 
-@import "bower_components/scally/utilities/u-alignments";
+@import "utilities/u-alignments";
 
-@import "bower_components/scally/utilities/u-toggle-visibility";
+@import "utilities/u-toggle-visibility";
 
-@import "bower_components/scally/utilities/u-image-replacement";
+@import "utilities/u-image-replacement";
 
-@import "bower_components/scally/utilities/u-link-complex";
+@import "utilities/u-link-complex";
 
-@import "bower_components/scally/utilities/u-link-disguised";
+@import "utilities/u-link-disguised";
 
-@import "bower_components/scally/utilities/u-link-no-underline";
+@import "utilities/u-link-no-underline";
 
-@import "bower_components/scally/utilities/u-momentum-scrolling";
+@import "utilities/u-momentum-scrolling";
 
-@import "bower_components/scally/utilities/u-float";
+@import "utilities/u-float";
 
-@import "bower_components/scally/utilities/u-new-block-formatting-context";
+@import "utilities/u-new-block-formatting-context";
 
-@import "bower_components/scally/utilities/u-flex-embed";
+@import "utilities/u-flex-embed";
 
-@import "bower_components/scally/utilities/u-gpu-accelerated";
+@import "utilities/u-gpu-accelerated";
 
-@import "bower_components/scally/utilities/u-position";
+@import "utilities/u-position";
 
-@import "bower_components/scally/utilities/u-display";
+@import "utilities/u-display";
 
-@import "bower_components/scally/utilities/u-spacing";
+@import "utilities/u-spacing";
 
-@import "bower_components/scally/utilities/u-divider";
+@import "utilities/u-divider";
 
-@import "bower_components/scally/utilities/u-overflow";
+@import "utilities/u-overflow";
 
-@import "bower_components/scally/utilities/u-overlay";
+@import "utilities/u-overlay";
 
-@import "bower_components/scally/utilities/u-cursor";
+@import "utilities/u-cursor";
 
 
 


### PR DESCRIPTION
The `to-em` and `to-rem` mixins were almost identical, but the `to-rem` didn't hadn't sledgehammering `!important` properly. They could also be improved slightly.

This commit:
- provides one generic mixin that's used by both `to-em` and `to-rem` to simplify the code.
- ensures `to-rem` uses the same sledgehammer technique so `10remtrue` isn't output
- doesn't convert any `0` values to em/rem to save bytes
- puts a space before `!important` as is the standard: http://cssguidelin.es/#important & https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity

You can see the difference in action here:
- Original: http://sassmeister.com/gist/9f811aefcfde73dcaab1
- Improved: http://sassmeister.com/gist/d841cbf7a6440dcd0a04

or see it here:

**SCSS**

``` scss

a {
  @include to-em(margin, 16);
  @include to-em(margin, 10, 12, true);
  @include to-rem(padding, 12);
  @include to-rem(padding, 12, true);
  @include to-em(text-shadow, (#0d6e28 1 1) (#777 0 0 2), 20);
  @include to-em(text-shadow, (#0d6e28 1 1) (#777 0 0 2), 20, true);
  @include to-rem(text-shadow, (#0d6e28 1 1) (#777 0 0 2));
  @include to-rem(text-shadow, (#0d6e28 1 1) (#777 0 0 2), true);
}
```

**Original**

``` css
a {
  margin: 1em;
  margin: 0.83333em!important;
  padding: 0.75rem;
  padding: 0.75remtrue;
  text-shadow: #0d6e28 0.05em 0.05em, #777 0em 0em 0.1em;
  text-shadow: #0d6e28 0.05em 0.05em, #777 0em 0em 0.1em!important;
  text-shadow: #0d6e28 0.0625rem 0.0625rem, #777 0rem 0rem 0.125rem;
  text-shadow: #0d6e28 0.0625rem 0.0625rem, #777 0rem 0rem 0.125remtrue;
}
```

**Improved**

``` css
a {
  margin: 1em;
  margin: 0.83333em !important;
  padding: 0.75rem;
  padding: 0.75rem !important;
  text-shadow: #0d6e28 0.05em 0.05em, #777 0 0 0.1em;
  text-shadow: #0d6e28 0.05em 0.05em, #777 0 0 0.1em !important;
  text-shadow: #0d6e28 0.0625rem 0.0625rem, #777 0 0 0.125rem;
  text-shadow: #0d6e28 0.0625rem 0.0625rem, #777 0 0 0.125rem !important;
}
```
