### PR TITLE
Converted to-em/rem mixins to be generic & fixed bugs

### DIFF
--- a/core/mixins/_convert-px-to-em-rem.scss
+++ b/core/mixins/_convert-px-to-em-rem.scss
@@ -71,7 +71,7 @@
  */
 
 @mixin to-em($properties, $sizes, $context: false, $sledgehammer: false) {
-  $context: if($context, $context, $font-size);
+  $context: if($context == false or $context == "", $font-size, $context);
   @include to-em-or-rem("em", $properties, $sizes, $context, $sledgehammer);
 }
 

--- a/core/mixins/_convert-px-to-em-rem.scss
+++ b/core/mixins/_convert-px-to-em-rem.scss
@@ -27,14 +27,17 @@
 
 
 /**
- * `em`.
+ * `em-or-rem`.
+ *
+ * Generic mixin which is used by the `to-em` and `to-rem` mixins below
  */
 
-@mixin to-em($properties, $sizes, $context: $font-size, $sledgehammer: false) {
+@mixin to-em-or-rem($unit, $properties, $sizes, $context, $sledgehammer) {
 
   $values: ();
   $sublists: false;
-  $important: if($sledgehammer, "!important", "");
+  $unit: if($unit == "em", unquote("em"), unquote("rem"));
+  $important: if($sledgehammer, " !important", "");
 
   @each $s in $sizes {
 
@@ -43,14 +46,14 @@
       $vv: ();
 
       @each $ss in $s {
-        $vv: append($vv, if(type-of($ss) == number, #{$ss / $context}em, $ss));
+        $vv: append($vv, if(type-of($ss) == number and $ss != 0, #{$ss / $context}#{$unit}, $ss));
       }
 
       $values: append($values, join((), $vv));
     }
 
     @else {
-      $values: append($values, if(type-of($s) == number, #{$s / $context}em,
+      $values: append($values, if(type-of($s) == number and $s != 0, #{$s / $context}#{$unit},
         $s));
     }
   }
@@ -64,37 +67,19 @@
 
 
 /**
+ * `em`.
+ */
+
+@mixin to-em($properties, $sizes, $context: false, $sledgehammer: false) {
+  $context: if($context, $context, $font-size);
+  @include to-em-or-rem("em", $properties, $sizes, $context, $sledgehammer);
+}
+
+
+/**
  * `rem`.
  */
 
-@mixin to-rem($properties, $sizes, $sledgehammer: "") {
-
-  $values: ();
-  $sublists: false;
-
-  @each $s in $sizes {
-
-    @if type-of($s) == list {
-      $sublists: true;
-      $vv: ();
-
-      @each $ss in $s {
-        $vv: append($vv, if(type-of($ss) == number, #{$ss / $font-size}rem,
-          $ss));
-      }
-
-      $values: append($values, join((), $vv));
-    }
-
-    @else {
-      $values: append($values, if(type-of($s) == number, #{$s / $font-size}rem,
-        $s));
-    }
-  }
-
-  $value: join((), $values, if($sublists, comma, space));
-
-  @each $prop in $properties {
-    #{$prop}: $value#{$sledgehammer};
-  }
+@mixin to-rem($properties, $sizes, $sledgehammer: false) {
+  @include to-em-or-rem("rem", $properties, $sizes, $font-size, $sledgehammer);
 }


### PR DESCRIPTION
The `to-em` and `to-rem` mixins were almost identical, but the `to-rem` didn't hadn't sledgehammering `!important` properly. They could also be improved slightly.

This commit:
- provides one generic mixin that's used by both `to-em` and `to-rem` to simplify the code.
- ensures `to-rem` uses the same sledgehammer technique so `10remtrue` isn't output
- doesn't convert any `0` values to em/rem to save bytes
- puts a space before `!important` as is the standard: http://cssguidelin.es/#important & https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity

You can see the difference in action here:
- Original: http://sassmeister.com/gist/9f811aefcfde73dcaab1
- Improved: http://sassmeister.com/gist/d841cbf7a6440dcd0a04

or see it here:

**SCSS**

``` scss

a {
  @include to-em(margin, 16);
  @include to-em(margin, 10, 12, true);
  @include to-rem(padding, 12);
  @include to-rem(padding, 12, true);
  @include to-em(text-shadow, (#0d6e28 1 1) (#777 0 0 2), 20);
  @include to-em(text-shadow, (#0d6e28 1 1) (#777 0 0 2), 20, true);
  @include to-rem(text-shadow, (#0d6e28 1 1) (#777 0 0 2));
  @include to-rem(text-shadow, (#0d6e28 1 1) (#777 0 0 2), true);
}
```

**Original**

``` css
a {
  margin: 1em;
  margin: 0.83333em!important;
  padding: 0.75rem;
  padding: 0.75remtrue;
  text-shadow: #0d6e28 0.05em 0.05em, #777 0em 0em 0.1em;
  text-shadow: #0d6e28 0.05em 0.05em, #777 0em 0em 0.1em!important;
  text-shadow: #0d6e28 0.0625rem 0.0625rem, #777 0rem 0rem 0.125rem;
  text-shadow: #0d6e28 0.0625rem 0.0625rem, #777 0rem 0rem 0.125remtrue;
}
```

**Improved**

``` css
a {
  margin: 1em;
  margin: 0.83333em !important;
  padding: 0.75rem;
  padding: 0.75rem !important;
  text-shadow: #0d6e28 0.05em 0.05em, #777 0 0 0.1em;
  text-shadow: #0d6e28 0.05em 0.05em, #777 0 0 0.1em !important;
  text-shadow: #0d6e28 0.0625rem 0.0625rem, #777 0 0 0.125rem;
  text-shadow: #0d6e28 0.0625rem 0.0625rem, #777 0 0 0.125rem !important;
}
```
