### PR TITLE
Fix font-size sledgehammer to be true or false

### DIFF
--- a/core/mixins/_font-size.scss
+++ b/core/mixins/_font-size.scss
@@ -44,6 +44,8 @@
    @include font-size(12, none);
    @include font-size(24, inherit);
    @include font-size(24, normal);
+   @include font-size(24, normal, true); or
+   @include font-size(24, normal, !important);
  *
  * @credit
  * https://github.com/inuitcss/tools.mixins/blob/master/_tools.mixins.scss

--- a/core/mixins/_font-size.scss
+++ b/core/mixins/_font-size.scss
@@ -50,19 +50,20 @@
  */
 
 
-@mixin font-size($font-size-value, $line-height-value: auto, $sledgehammer: "") {
+@mixin font-size($font-size-value, $line-height-value: auto, $sledgehammer: false) {
 
-  font-size: ($font-size-value / $font-size) * 1rem#{$sledgehammer};
+  $important: if($sledgehammer, " !important", "");
+  font-size: ($font-size-value / $font-size) * 1rem#{$important};
 
   @if $line-height-value == auto {
     line-height: ceil($font-size-value / $line-height) * ($line-height /
-      $font-size-value)#{$sledgehammer};
+      $font-size-value)#{$important};
   }
   @else {
 
     @if (type-of($line-height-value) == number or $line-height-value == inherit
       or $line-height-value == normal) {
-      line-height: $line-height-value#{$sledgehammer};
+      line-height: $line-height-value#{$important};
     }
     @elseif ($line-height-value != none and $line-height-value != false) {
       @warn "D'oh! `#{$line-height-value}` is not a valid value for `line-height`."

--- a/style.css
+++ b/style.css
@@ -3249,40 +3249,40 @@ li:before {
  * Size.
  */
 .u-text-size-small {
-  font-size: 0.9375rem!important;
-  line-height: 1.6!important; }
+  font-size: 0.9375rem !important;
+  line-height: 1.6 !important; }
 
 .u-text-size-x-small {
-  font-size: 0.875rem!important;
-  line-height: 1.71429!important; }
+  font-size: 0.875rem !important;
+  line-height: 1.71429 !important; }
 
 .u-text-size-xx-small {
-  font-size: 0.8125rem!important;
-  line-height: 1.84615!important; }
+  font-size: 0.8125rem !important;
+  line-height: 1.84615 !important; }
 
 .u-text-size-xxx-small {
-  font-size: 0.75rem!important;
-  line-height: 2!important; }
+  font-size: 0.75rem !important;
+  line-height: 2 !important; }
 
 .u-text-size-large {
-  font-size: 1.0625rem!important;
-  line-height: 1.41176!important; }
+  font-size: 1.0625rem !important;
+  line-height: 1.41176 !important; }
 
 .u-text-size-x-large {
-  font-size: 1.125rem!important;
-  line-height: 1.33333!important; }
+  font-size: 1.125rem !important;
+  line-height: 1.33333 !important; }
 
 .u-text-size-xx-large {
-  font-size: 1.1875rem!important;
-  line-height: 1.26316!important; }
+  font-size: 1.1875rem !important;
+  line-height: 1.26316 !important; }
 
 .u-text-size-xxx-large {
-  font-size: 1.25rem!important;
-  line-height: 1.2!important; }
+  font-size: 1.25rem !important;
+  line-height: 1.2 !important; }
 
 .u-text-size-base {
-  font-size: 1rem!important;
-  line-height: 1.5!important; }
+  font-size: 1rem !important;
+  line-height: 1.5 !important; }
 
 .u-text-size-inherit {
   font-size: inherit !important; }


### PR DESCRIPTION
This changes the sledgehammer/important logic so that any truthy value will result in `!important`. It uses the same logic as [my `to-em/rem` PR](https://github.com/stowball/scally/blob/generic-em-rem-mixin/core/mixins/_convert-px-to-em-rem.scss#L40).

This allows people to pass in the more concise `true` as the argument, and not have `10remtrue` output. It also means that `10remsausage` will never be feasible, instead `10rem !important` will be output.
