### PR TITLE
Updated retina-bg-image mixin & created new respond-retina mixin. Fixes #123

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,8 @@ Here is a sample of a master stylesheet you could use for your `style.scss`:
 
 @import "[path/to/the/scally/framework]/core/settings/spacing";
 
+@import "[path/to/the/scally/framework]/core/settings/retina-resolution";
+
 @import "[path/to/the/scally/framework]/core/settings/breakpoints";
 
 @import "[path/to/the/scally/framework]/core/settings/widths";

--- a/core/mixins/_media-queries.scss
+++ b/core/mixins/_media-queries.scss
@@ -5,11 +5,11 @@
 
 /**
  * Setup media queries for minimum and maximum widths and heights, with width
- * being the default, also includes the ability to apply ranges. The mixin will
- * accept any of Scally's breakpoints defined here: Core -> Settings ->
- * Breakpoints or any integer. For `max-width` media queries the "max" flag
- * needs to be applied, and for height media queries the `$axis` parameter
- * needs to be set to "height".
+ * being the default, also includes the ability to apply ranges and respond to
+ * retina/hi-dpi devices. The mixin will accept any of Scally's breakpoints
+ * defined here: Core -> Settings -> Breakpoints or any integer. For `max-width`
+ * media queries the "max" flag needs to be applied, and for height media
+ * queries the `$axis` parameter needs to be set to "height".
  *
  * N.B. a `px` unit is not necessary but will work if specified e.g. "400" is
  * fine, so is "400px" e.g.
@@ -45,6 +45,14 @@
 
    @include respond-range(lap) {
      .foo {background: red;}
+   }
+
+   @include respond-retina(2) {
+     .foo {background-size: 100px auto;}
+   }
+
+  @include respond-retina(144dpi) {
+     .foo {background-size: 100px auto;}
    }
  */
 
@@ -94,6 +102,19 @@
   }// endif
 
   @media (min-#{$axis}: to-em(strip-unit($min-value), 16)) and (max-#{$axis}: to-em(strip-unit($max-value), 16)) {
+    @content;
+  }
+}
+
+
+/**
+ * Retina.
+ */
+
+@mixin respond-retina($resolution: $retina-resolution) {
+  $resolution: if(unitless($resolution), $resolution * 96dpi, $resolution);
+  
+  @media (min-resolution: $resolution) {
     @content;
   }
 }

--- a/core/mixins/_retina-bg-image.scss
+++ b/core/mixins/_retina-bg-image.scss
@@ -9,7 +9,7 @@
  * @example
    .foo {
       background: url("logo.png") no-repeat;
-      @include retina-bg-image("logo@2x.png", 100px, 25px);
+      @include retina-bg-image("logo@2x.png", 100px, 25px, 1.5);
     }
   *
   * @credit
@@ -17,11 +17,13 @@
  */
 
 
-@mixin retina-bg-image($image, $width, $height) {
-  @media (-o-min-device-pixel-ratio: 5/4),
-         (-webkit-min-device-pixel-ratio: 1.25),
-         (min-resolution: 120dpi) {
-           background-image: url($image);
-           background-size: $width $height;
+@mixin retina-bg-image($image, $width: auto, $height: auto, $resolution: $retina-resolution) {
+  $width: if($width, $width, auto);
+  $height: if($height, $height, auto);
+  $resolution: if(unitless($resolution), $resolution * 96dpi, $resolution);
+  
+  @media (min-resolution: $resolution) {
+    background-image: url($image);
+    background-size: $width $height;
   }
 }

--- a/core/settings/_breakpoints.scss
+++ b/core/settings/_breakpoints.scss
@@ -5,7 +5,7 @@
 
 /**
  * Here we set breakpoints. Not every media query will be able to use one of
- * these breakpoints and that's fine as they're no magic numbers with
+ * these breakpoints and that's fine as there are no magic numbers with
  * breakpoints i.e. if the UI needs to change then it needs to change. But
  * most of the time we can use them.
  *
@@ -20,9 +20,9 @@
  *   portable that doesn't include phones.
  * - Lap small: smaller tablets/notebooks and e-readers e.g. Kindle.
  * - Lap large: larger tablets and laptops.
- * - Desk: desktop computers, TV's, etc. i.e. anything that is not portable.
+ * - Desk: desktop computers, TVs, etc. i.e. anything that is not portable.
  * - Desk small: smaller desktop computer monitors.
- * - Desk large: larger desktop computer monitors, TV's, and who knows what
+ * - Desk large: larger desktop computer monitors, TVs, and who knows what
  *   else?
  *
  * The breakpoints:
@@ -59,7 +59,7 @@ $breakpoints: (
 
 /**
  * A global setting to define the common breakpoint(s) for Scally and your
- * project. This is mainly used by the Generate at breakpoints mixin.
+ * project. This is mainly used by the `generate-at-breakpoints()` mixin.
  */
 
 $default-breakpoints: (lap) !default;

--- a/core/settings/_retina-resolution.scss
+++ b/core/settings/_retina-resolution.scss
@@ -1,0 +1,14 @@
+/* ============================================================================
+   @CORE -> SETTINGS -> RETINA RESOLUTION
+   ========================================================================= */
+
+
+/**
+ * A global setting to define the dpr/dpi for retina mixins.
+ * Default value set to 1.3 to target Google Nexus 7
+ * (http://bjango.com/articles/min-device-pixel-ratio/)
+ *
+ * Can be either a unitless dpr (1.5) or a dpi (144dpi)
+ */
+
+$retina-resolution: 1.3 !default;


### PR DESCRIPTION
As discussed, the `retina-bg-image()` mixin:
- has had the vendor prefixes removed
- has set the `$width` and `$height` arguments to `auto` to reduce developer input
- allows for a `$resolution` argument, which defaults to the `$retina-resolution !default`. If a unitless dpr is provided, it will be converted to a dpi, otherwise it's left alone. Autoprefixer will generate the necessary `-webkit-device-pixel-ratio` prefix

The default resolution ratio has been bumped from 1.25 to 1.3.

A generic, `respond-retina()` mixin has been created which renders any `@contents` passed to it. It has the same resolution support/logic as `retina-bg-image`. This mixin allows developers that are used to the majority of other frameworks to continue developing as they have always done, and the freedom to use properties other than `background-image/size`.

I also improved some `_breakpoints.scss` docs (typos etc). 
