### PR TITLE
Issue 136: Add available object classes to intro block

### DIFF
--- a/objects/_o-arrow.scss
+++ b/objects/_o-arrow.scss
@@ -6,6 +6,18 @@
 /**
  * Creates arrow shapes using only CSS.
  *
+ * All the objects (available as silent placeholder selectors also):
+ *
+   .o-arrow
+   .o-arrow--tiny
+   .o-arrow--small
+   .o-arrow--large
+   .o-arrow--huge
+   .o-arrow--down
+   .o-arrow--up
+   .o-arrow--left
+   .o-arrow--right
+ *
  * @markup
    <span class="o-arrow [modifier(s)]"></span>
  *

--- a/objects/_o-arrow.scss
+++ b/objects/_o-arrow.scss
@@ -6,7 +6,7 @@
 /**
  * Creates arrow shapes using only CSS.
  *
- * All the objects (available as silent placeholder selectors also):
+ * All the objects and their children (available as silent placeholder selectors also):
  *
    .o-arrow
    .o-arrow--tiny

--- a/objects/_o-drop-down.scss
+++ b/objects/_o-drop-down.scss
@@ -11,7 +11,8 @@
  * trigger is selected. There is also a version for showing the drop down via
  * the `:hover` pseudo class which is turned off for touch devices.
  *
- * All the objects and their children (available as silent placeholder selectors also):
+ * The objects block class, its modifier class(s), and its element class(s)
+ * (available as silent placeholder selectors also):
  *
    .o-drop-down
    .o-drop-down__target

--- a/objects/_o-drop-down.scss
+++ b/objects/_o-drop-down.scss
@@ -11,7 +11,7 @@
  * trigger is selected. There is also a version for showing the drop down via
  * the `:hover` pseudo class which is turned off for touch devices.
  *
- * All the objects (available as silent placeholder selectors also):
+ * All the objects and their children (available as silent placeholder selectors also):
  *
    .o-drop-down
    .o-drop-down__target

--- a/objects/_o-drop-down.scss
+++ b/objects/_o-drop-down.scss
@@ -11,6 +11,11 @@
  * trigger is selected. There is also a version for showing the drop down via
  * the `:hover` pseudo class which is turned off for touch devices.
  *
+ * All the objects (available as silent placeholder selectors also):
+ *
+   .o-drop-down
+   .o-drop-down__target
+ *
  * @markup
    <div class="o-drop-down">
      <!-- The trigger -->

--- a/objects/_o-flexible-embed.scss
+++ b/objects/_o-flexible-embed.scss
@@ -7,7 +7,8 @@
  * For use with embeds like videos, iframes, or even images that need to retain
  * a specific aspect ratio but adapt to the width of their containing element.
  *
- * All the objects and their children (available as silent placeholder selectors also):
+ * The objects block class, its modifier class(s), and its element class(s)
+ * (available as silent placeholder selectors also):
  *
    .o-flexible-embed
    .o-flexible-embed__ratio

--- a/objects/_o-flexible-embed.scss
+++ b/objects/_o-flexible-embed.scss
@@ -7,7 +7,7 @@
  * For use with embeds like videos, iframes, or even images that need to retain
  * a specific aspect ratio but adapt to the width of their containing element.
  *
- * All the objects (available as silent placeholder selectors also):
+ * All the objects and their children (available as silent placeholder selectors also):
  *
    .o-flexible-embed
    .o-flexible-embed__ratio

--- a/objects/_o-flexible-embed.scss
+++ b/objects/_o-flexible-embed.scss
@@ -7,6 +7,15 @@
  * For use with embeds like videos, iframes, or even images that need to retain
  * a specific aspect ratio but adapt to the width of their containing element.
  *
+ * All the objects (available as silent placeholder selectors also):
+ *
+   .o-flexible-embed
+   .o-flexible-embed__ratio
+   .o-flexible-embed__ratio--16-by-9
+   .o-flexible-embed__ratio--2-by-1
+   .o-flexible-embed__ratio--4-by-3
+   .o-flexible-embed__content
+ *
  * @markup
    <div class="o-flexible-embed">
      <!-- The content e.g. a video (`iframe`) -->

--- a/objects/_o-link-complex.scss
+++ b/objects/_o-link-complex.scss
@@ -8,7 +8,8 @@
  * icon, where only one piece of text should act like a link when the link is
  * the subject of user interaction.
  *
- * All the objects and their children (available as silent placeholder selectors also):
+ * The objects block class, its modifier class(s), and its element class(s)
+ * (available as silent placeholder selectors also):
  *
    .o-link-complex
    .o-link-complex__target

--- a/objects/_o-link-complex.scss
+++ b/objects/_o-link-complex.scss
@@ -8,7 +8,7 @@
  * icon, where only one piece of text should act like a link when the link is
  * the subject of user interaction.
  *
- * All the objects (available as silent placeholder selectors also):
+ * All the objects and their children (available as silent placeholder selectors also):
  *
    .o-link-complex
    .o-link-complex__target

--- a/objects/_o-link-complex.scss
+++ b/objects/_o-link-complex.scss
@@ -8,6 +8,11 @@
  * icon, where only one piece of text should act like a link when the link is
  * the subject of user interaction.
  *
+ * All the objects (available as silent placeholder selectors also):
+ *
+   .o-link-complex
+   .o-link-complex__target
+ *
  * @markup
    <a class="o-link-complex" href="#">
      Link complex

--- a/objects/_o-list-block.scss
+++ b/objects/_o-list-block.scss
@@ -7,6 +7,14 @@
  * Creates blocky list items out of a `ul` or `ol` which is usually for a
  * vertical list of links.
  *
+ * All the objects (available as silent placeholder selectors also):
+ *
+   .o-list-block
+   .o-list-block--tiny
+   .o-list-block--small
+   .o-list-block--large
+   .o-list-block--huge
+ *
  * @markup
    <ul class="o-list-block [modifier]">
      <li>
@@ -58,7 +66,7 @@ $o-list-block-item-padding-large:                $spacing-base !default;
 $o-list-block-item-padding-huge:                 $spacing-double !default;
 
 
-%u-list-block > li,
+%o-list-block > li,
 .o-list-block > li {
 
   &,
@@ -89,7 +97,7 @@ $o-list-block-item-padding-huge:                 $spacing-double !default;
  * Modifier: tiny padding.
  */
 
-%u-list-block--tiny > li,
+%o-list-block--tiny > li,
 .o-list-block--tiny > li {
 
   &,
@@ -114,7 +122,7 @@ $o-list-block-item-padding-huge:                 $spacing-double !default;
  * Modifier: small padding.
  */
 
-%u-list-block--small > li,
+%o-list-block--small > li,
 .o-list-block--small > li {
   &,
   > a {@include to-rem(padding, $o-list-block-item-padding-small);}
@@ -138,7 +146,7 @@ $o-list-block-item-padding-huge:                 $spacing-double !default;
  * Modifier: large padding.
  */
 
-%u-list-block--large > li,
+%o-list-block--large > li,
 .o-list-block--large > li {
 
   &,
@@ -163,7 +171,7 @@ $o-list-block-item-padding-huge:                 $spacing-double !default;
  * Modifier: huge padding.
  */
 
-%u-list-block--huge > li,
+%o-list-block--huge > li,
 .o-list-block--huge > li {
 
   &,

--- a/objects/_o-list-block.scss
+++ b/objects/_o-list-block.scss
@@ -7,7 +7,7 @@
  * Creates blocky list items out of a `ul` or `ol` which is usually for a
  * vertical list of links.
  *
- * All the objects (available as silent placeholder selectors also):
+ * All the objects and their children (available as silent placeholder selectors also):
  *
    .o-list-block
    .o-list-block--tiny

--- a/objects/_o-list-block.scss
+++ b/objects/_o-list-block.scss
@@ -7,7 +7,8 @@
  * Creates blocky list items out of a `ul` or `ol` which is usually for a
  * vertical list of links.
  *
- * All the objects and their children (available as silent placeholder selectors also):
+ * The objects block class, its modifier class(s), and its element class(s)
+ * (available as silent placeholder selectors also):
  *
    .o-list-block
    .o-list-block--tiny

--- a/objects/_o-list-inline.scss
+++ b/objects/_o-list-inline.scss
@@ -12,7 +12,8 @@
  * inserting HTML comments between the opening and closing `li`s (see @markup
  * section below). Or you can omit the closing `li` which isn't recommended :)
  *
- * All the objects and their children (available as silent placeholder selectors also):
+ * The objects block class, its modifier class(s), and its element class(s)
+ * (available as silent placeholder selectors also):
  *
    .o-list-inline
    .o-list-inline--spacing-base

--- a/objects/_o-list-inline.scss
+++ b/objects/_o-list-inline.scss
@@ -12,7 +12,7 @@
  * inserting HTML comments between the opening and closing `li`s (see @markup
  * section below). Or you can omit the closing `li` which isn't recommended :)
  *
- * All the objects (available as silent placeholder selectors also):
+ * All the objects and their children (available as silent placeholder selectors also):
  *
    .o-list-inline
    .o-list-inline--spacing-base
@@ -30,7 +30,6 @@
    .o-list-inline--fit-table
    .o-list-inline--delimited-slash
    .o-list-inline--delimited-comma
-
  *
  * @markup
    <ul class="o-list-inline [modifiers(s)]">

--- a/objects/_o-list-inline.scss
+++ b/objects/_o-list-inline.scss
@@ -12,6 +12,26 @@
  * inserting HTML comments between the opening and closing `li`s (see @markup
  * section below). Or you can omit the closing `li` which isn't recommended :)
  *
+ * All the objects (available as silent placeholder selectors also):
+ *
+   .o-list-inline
+   .o-list-inline--spacing-base
+   .o-list-inline--spacing-base-both
+   .o-list-inline--spacing-tiny
+   .o-list-inline--spacing-tiny-both
+   .o-list-inline--spacing-small
+   .o-list-inline--spacing-small-both
+   .o-list-inline--spacing-large
+   .o-list-inline--spacing-large-both
+   .o-list-inline--spacing-huge
+   .o-list-inline--spacing-huge-both
+   .o-list-inline--divider
+   .o-list-inline--fit-flexbox
+   .o-list-inline--fit-table
+   .o-list-inline--delimited-slash
+   .o-list-inline--delimited-comma
+
+ *
  * @markup
    <ul class="o-list-inline [modifiers(s)]">
      <li>Lorem</li><!--

--- a/objects/_o-list.scss
+++ b/objects/_o-list.scss
@@ -7,7 +7,7 @@
  * Standard list styles for unordered and ordered lists as they're removed in
  * Core -> Reset.
  *
- * All the objects (available as silent placeholder selectors also):
+ * All the objects  and their children (available as silent placeholder selectors also):
  *
    .o-list
    ul.o-list

--- a/objects/_o-list.scss
+++ b/objects/_o-list.scss
@@ -7,6 +7,12 @@
  * Standard list styles for unordered and ordered lists as they're removed in
  * Core -> Reset.
  *
+ * All the objects (available as silent placeholder selectors also):
+ *
+   .o-list
+   ul.o-list
+   ol.o-list
+ *
  * @markup
    <ul class="o-list">
      <li>Lorem</li>

--- a/objects/_o-list.scss
+++ b/objects/_o-list.scss
@@ -7,12 +7,6 @@
  * Standard list styles for unordered and ordered lists as they're removed in
  * Core -> Reset.
  *
- * All the objects  and their children (available as silent placeholder selectors also):
- *
-   .o-list
-   ul.o-list
-   ol.o-list
- *
  * @markup
    <ul class="o-list">
      <li>Lorem</li>

--- a/objects/_o-overlay.scss
+++ b/objects/_o-overlay.scss
@@ -22,7 +22,8 @@
  * And this may end up not being used instead being sucked into a component
  * e.g. a Modal component.
  *
- * All the objects and their children (available as silent placeholder selectors also):
+ * The objects block class, its modifier class(s), and its element class(s)
+ * (available as silent placeholder selectors also):
  *
   .o-overlay
   .o-overlay--in-context

--- a/objects/_o-overlay.scss
+++ b/objects/_o-overlay.scss
@@ -22,6 +22,14 @@
  * And this may end up not being used instead being sucked into a component
  * e.g. a Modal component.
  *
+  * All the objects (available as silent placeholder selectors also):
+ *
+   .o-overlay
+   .o-overlay--in-context
+
+   .o-overlay--hover
+
+ *
  * @markup
    <div class="o-overlay [modifier]">
      <div class="o-overlay__inner"></div>

--- a/objects/_o-overlay.scss
+++ b/objects/_o-overlay.scss
@@ -22,13 +22,14 @@
  * And this may end up not being used instead being sucked into a component
  * e.g. a Modal component.
  *
-  * All the objects (available as silent placeholder selectors also):
+ * All the objects and their children (available as silent placeholder selectors also):
  *
-   .o-overlay
-   .o-overlay--in-context
-
-   .o-overlay--hover
-
+  .o-overlay
+  .o-overlay--in-context
+  .o-overlay--dark
+  .o-overlay--light
+  .o-overlay--hover
+  .o-overlay__inner
  *
  * @markup
    <div class="o-overlay [modifier]">

--- a/objects/_o-table.scss
+++ b/objects/_o-table.scss
@@ -7,6 +7,17 @@
  * A table object that provides very common table styles which can be
  * extended with a number of modifiers.
  *
+ * All the objects (available as silent placeholder selectors also):
+ *
+   .o-table
+   .o-table--striped
+   .o-table--border
+   .o-table--fixed
+   .o-table--cell-padding-small
+   .o-table--cell-padding-large
+   .o-table--no-cell-padding
+
+ *
  * @markup
    <table class="o-table [modifier(s)]" cellspacing="0">
      <tr>

--- a/objects/_o-table.scss
+++ b/objects/_o-table.scss
@@ -7,7 +7,8 @@
  * A table object that provides very common table styles which can be
  * extended with a number of modifiers.
  *
- * All the objects and their children (available as silent placeholder selectors also):
+ * The objects block class, its modifier class(s), and its element class(s)
+ * (available as silent placeholder selectors also):
  *
    .o-table
    .o-table--striped

--- a/objects/_o-table.scss
+++ b/objects/_o-table.scss
@@ -7,7 +7,7 @@
  * A table object that provides very common table styles which can be
  * extended with a number of modifiers.
  *
- * All the objects (available as silent placeholder selectors also):
+ * All the objects and their children (available as silent placeholder selectors also):
  *
    .o-table
    .o-table--striped
@@ -16,7 +16,6 @@
    .o-table--cell-padding-small
    .o-table--cell-padding-large
    .o-table--no-cell-padding
-
  *
  * @markup
    <table class="o-table [modifier(s)]" cellspacing="0">


### PR DESCRIPTION
This fixes #136 and corrects the silent placeholders in `o-list-block`.

@chris-pearce I am unsure how to handle some of the nested classes seen in `o-list` and `o-overlay`? 
