### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,5 @@
   "bugs": {
     "url": "https://github.com/chris-pearce/scally/issues"
   },
-  "license": {
-    "type": "Apache 2",
-    "url":  "https://github.com/chris-pearce/scally/blob/master/LICENSE"
-  }
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
