### PR TITLE
Issue 132: Base link mixin doesn't work very well

### DIFF
--- a/components/_c-button-faux-link.scss
+++ b/components/_c-button-faux-link.scss
@@ -18,4 +18,30 @@
 .c-button-faux-link {
   @extend %o-button;
   @include base-link();
+
+  // We have to repeat the following styles and `@if` statements from the
+  // `base-link()` mixin as this component uses the Button object which sets
+  // `text-decoration: none;` for all states
+  text-decoration: underline;
+
+  // Remove underline and apply on hover
+  @if $apply-link-underline-on-hover {
+    text-decoration: none;
+
+    &:hover,
+    &:focus,
+    &:active {
+      text-decoration: underline;
+
+      @if $apply-link-underline-on-hover and
+      $apply-link-border-instead-of-underline {
+        text-decoration: none;
+      }
+    }
+  }
+
+  // Apply a border as the underline instead of `text-decoration: underline`
+  @if $apply-link-border-instead-of-underline {
+    text-decoration: none;
+  }
 }

--- a/core/base/_links.scss
+++ b/core/base/_links.scss
@@ -4,13 +4,19 @@
 
 
 /**
- * Base link styles, at the bare minimum a colour is applied for both default
+ * Base link styles. At the bare minimum a colour is applied for both default
  * and hover states. There is the option to remove the underline for the
- * default state and apply on hover state and an option to transition the
- * colour on hover.
+ * default state and apply it on the hover state instead, and an option to
+ * apply a bottom border as the underline instead of the browser default
+ * `text-decoration: underline`. You can also choose to apply a transition to
+ *  link colour and its underline—if the bottom border option is selected—when
+ *  hovering the link.
  *
  * N.B. a mixin is used to contain the base link styles so that it can be
- * easily shared with other parts of Scally e.g. Link complex object.
+ * easily shared with other parts of Scally e.g.
+ *
+ * - Link complex object
+ * - Button faux component
  */
 
 
@@ -19,32 +25,58 @@
  */
 
 // Toggle on/off certain styles and treatments
-$apply-link-underline-on-hover:     true !default;
+$apply-link-underline-on-hover:           true !default;
 
-$apply-link-transition-on-hover:    true !default;
+$apply-link-transition-on-hover:          true !default;
+
+$apply-link-border-instead-of-underline:  false !default;
 
 // Colours
-$link-color:                        $color-brand !default;
+$link-color:                              $color-brand !default;
 
-$link-color-hover:                  darken($link-color, 10%) !default;
+$link-color-hover:                        darken($link-color, 10%) !default;
 
 // Transition parameters
-$link-transition-duration:          0.15s !default;
+$link-transition-duration:                0.15s !default;
 
-$link-transition-timing-function:   ease !default;
+$link-transition-timing-function:         ease !default;
+
+// Border styles
+$link-border-thickness:                   1 !default;
+
+$link-border-style:                       solid !default;
+
+$link-border-color:                       $link-color !default;
+
+$link-border-color-hover:                 $link-color-hover !default;
 
 
 @mixin base-link {
   color: $link-color;
+  text-decoration: underline;
 
   // Remove underline and apply on hover
   @if $apply-link-underline-on-hover {
     text-decoration: none;
   }
 
+  // Apply a border as the underline instead of `text-decoration: underline`
+  @if $apply-link-border-instead-of-underline {
+    border-bottom: strip-unit($link-border-thickness) * 1px
+    $link-border-style $link-border-color;
+    text-decoration: none;
+  }
+
+  // Remove the border colour but only visually if it's to be applied on hover,
+  // this ensures the transition is seamless
+  @if $apply-link-underline-on-hover and
+  $apply-link-border-instead-of-underline {
+    border-bottom-color: transparent;
+  }
+
   // Apply a transition on hover
   @if $apply-link-transition-on-hover {
-    transition: color $link-transition-duration
+    transition: all $link-transition-duration
     $link-transition-timing-function;
   }
 
@@ -54,6 +86,16 @@ $link-transition-timing-function:   ease !default;
 
     @if $apply-link-underline-on-hover {
       text-decoration: underline;
+    }
+
+    @if $apply-link-border-instead-of-underline {
+      border-bottom-color: $link-border-color-hover;
+    }
+
+    @if $apply-link-underline-on-hover and
+    $apply-link-border-instead-of-underline {
+      border-bottom-color: $link-border-color-hover;
+      text-decoration: none;
     }
   }
 }

--- a/objects/_o-link-complex.scss
+++ b/objects/_o-link-complex.scss
@@ -78,7 +78,7 @@ $o-link-complex-apply-at-breakpoints-for-target:   false !default;
   @if $o-link-complex-apply-at-breakpoints-for-target {
     @include generate-at-breakpoints('.o-link-complex__target',
       $o-link-complex-apply-at-breakpoints) {
-      cursor: pointer;
       @include base-link();
+      cursor: pointer;
     }
   }


### PR DESCRIPTION
This fixes #132—well not 100% but I think its enough.

I provided the option to apply a `border-bottom` instead of the default `text-decoration: underline` which provides enough styling options for a Base link IMO and keeps this Base element from going overboard with customisations especially when Scally's Base styles should be as light and unopinionated as possible. 

If a Scally user wishes to add more to the Base link styles—beyond what Scally provides—in their project layer then they're free to do so, it just means that the [Link complex object](https://github.com/chris-pearce/scally/blob/master/objects/_o-link-complex.scss) and [Button faux link component](https://github.com/chris-pearce/scally/blob/master/components/_c-button-faux-link.scss) also need to be updated as they need the same Base link styles.
