### PR TITLE
Issue 168: Apply a setting to remove the bottom spacing half from H4–H6 headings

### DIFF
--- a/core/base/_headings.scss
+++ b/core/base/_headings.scss
@@ -12,7 +12,10 @@
  * Settings.
  */
 
-$apply-heading-margins: true !default;
+// Margins
+$apply-heading-margins:                     true !default;
+
+$apply-smaller-margin-for-lowest-headings:  true !default;
 
 
 /**
@@ -34,9 +37,17 @@ $apply-heading-margins: true !default;
     @extend %bottom-spacing;
   }
 
-  // Half
-  @include headings(4, 6, true) {
-    @extend %bottom-spacing-half;
+  @if $apply-smaller-margin-for-lowest-headings {
+    // Half
+    @include headings(4, 6, true) {
+      @extend %bottom-spacing-half;
+    }
+  }
+  @else {
+    // Base
+    @include headings(4, 6, true) {
+      @extend %bottom-spacing;
+    }
   }
 }
 

--- a/core/functions/_convert-px-to-em-rem.scss
+++ b/core/functions/_convert-px-to-em-rem.scss
@@ -29,7 +29,8 @@
   @if type-of($value) == "string" {
     @if map-has-key($breakpoints, $value) {
       $value: map-get($breakpoints, $value);
-    } @else {
+    }
+    @else {
       @warn "Breakpoint name '#{$value}' not recognised.";
     }
   }


### PR DESCRIPTION
This fixes #168. 
