### PR TITLE
Issue 167: Fix whitespace coming between semi-colon and end of property value in Font Size mixin

### DIFF
--- a/core/mixins/_font-size.scss
+++ b/core/mixins/_font-size.scss
@@ -107,6 +107,10 @@
    .foo {
      @include font-size(24, 1.2, !important);
    }
+
+   .foo {
+     @include font-size(24, auto, !important);
+   }
  *
  * @credit
  * https://github.com/inuitcss/tools.mixins/blob/master/_tools.mixins.scss
@@ -115,26 +119,26 @@
 
 @mixin font-size($font-size-value, $line-height-value: auto, $sledgehammer: false) {
 
-  $important: if($sledgehammer, "!important", "");
+  $important: if($sledgehammer, " !important", "");
   $font-size-value: strip-unit($font-size-value);
 
-  font-size: ($font-size-value / strip-unit($font-size)) * 1rem #{$important};
+  font-size: (($font-size-value / strip-unit($font-size)) * 1rem)#{$important};
 
   @if $line-height-value == auto {
     line-height: ceil($font-size-value / $line-height) * ($line-height /
-      $font-size-value) #{$important};
+      $font-size-value)#{$important};
   }
   @else {
     @if (type-of($line-height-value) == number) {
       @if unitless($line-height-value) {
-        line-height: $line-height-value #{$important};
+        line-height: $line-height-value#{$important};
       }
       @else {
-        line-height: strip-unit($line-height-value) / $font-size-value #{$important};
+        line-height: strip-unit($line-height-value) / $font-size-value#{$important};
       }
     }
     @elseif $line-height-value == inherit or $line-height-value == normal {
-      line-height: $line-height-value #{$important};
+      line-height: $line-height-value#{$important};
     }
     @elseif ($line-height-value != none and $line-height-value != false) {
       @warn "D'oh! `#{$line-height-value}` is not a valid value for `line-height`."


### PR DESCRIPTION
This fixes #167.
