### PR TITLE
Add parent selector to produce correct output

### DIFF
--- a/core/mixins/_text-input-placeholder-colour.scss
+++ b/core/mixins/_text-input-placeholder-colour.scss
@@ -24,18 +24,18 @@
 
 @mixin text-input-placeholder-color($color: $color-text-input-placeholder) {
   // Webkit
-  ::-webkit-input-placeholder {color: $color;}
+  &::-webkit-input-placeholder {color: $color;}
 
   // Firefox 19+
-  ::-moz-placeholder {
+  &::-moz-placeholder {
     color: $color;
     opacity: 1;
   }
 
   // IE
-  :-ms-input-placeholder {color: $color;}
+  &:-ms-input-placeholder {color: $color;}
 
   // Standard
-  :input-placeholder {color: $color;}
-  ::input-placeholder {color: $color;}
+  &:input-placeholder {color: $color;}
+  &::input-placeholder {color: $color;}
 }


### PR DESCRIPTION
Without the parent selector the output for this:

``` scss
   .foo {
     @include text-input-placeholder-color($color);
   }
```

is:

``` scss
   .foo ::-webkit-input-placeholder {
        color: $color;
   }
```

with a space between class and selector
whereas it should be: 

``` scss
   .foo::-webkit-input-placeholder {
        color: $color;
   }
```

with no space
